### PR TITLE
SystemUI: Add config to disable HumanInteractionClassifier

### DIFF
--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -85,4 +85,7 @@
 
     <!-- Message to show the user when their vendor image doesn't match the build's fingerprint. -->
     <java-symbol type="string" name="lineage_system_error_manufacturer" />
+
+    <!-- Whether to enable HumanInteractionController by default -->
+    <java-symbol type="bool" name="config_HICEnabledDefault" />
 </resources>

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2802,4 +2802,7 @@
     <!-- Support in Surfaceflinger for blur layers.
          NOTE: This requires additional hardware-specific code. -->
     <bool name="config_uiBlurEnabled">false</bool>
+
+    <!-- Whether to enable HumanInteractionController by default -->
+    <bool name="config_HICEnabledDefault">true</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/classifier/HumanInteractionClassifier.java
+++ b/packages/SystemUI/src/com/android/systemui/classifier/HumanInteractionClassifier.java
@@ -36,9 +36,6 @@ public class HumanInteractionClassifier extends Classifier {
     private static final String HIC_ENABLE = "HIC_enable";
     private static final float FINGER_DISTANCE = 0.1f;
 
-    /** Default value for the HIC_ENABLE setting: 1 - enabled, 0 - disabled */
-    private static final int HIC_ENABLE_DEFAULT = 1;
-
     private static HumanInteractionClassifier sInstance = null;
 
     private final Handler mHandler = new Handler();
@@ -105,9 +102,11 @@ public class HumanInteractionClassifier extends Classifier {
     }
 
     private void updateConfiguration() {
+        boolean enabledDefault = mContext.getResources()
+                .getBoolean(com.android.internal.R.bool.config_HICEnabledDefault);
         mEnableClassifier = 0 != Settings.Global.getInt(
                 mContext.getContentResolver(),
-                HIC_ENABLE, HIC_ENABLE_DEFAULT);
+                HIC_ENABLE, enabledDefault ? 1 : 0);
     }
 
     public void setType(int type) {


### PR DESCRIPTION
On some devices HumaInteractionClassifier is more of a nuisance than a
useful feature by making the screen hard to unlock at random. Add a
config that allows to define the default state of HIC, which currently
can only be disabled running the following command:

  settings put global HIC_enable 0

Change-Id: I3ad85aff08fe209a21f1eae8a8719c089ed7aa28