### PR TITLE
VolumeDialog: Fix mismerge

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialog.java
@@ -666,7 +666,7 @@ public class VolumeDialog implements TunerService.Tunable {
 
     private void removeRow(VolumeRow volumeRow) {
         mRows.remove(volumeRow);
-        mDialogContentView.removeView(volumeRow.view);
+        mDialogRowsView.removeView(volumeRow.view);
     }
 
     private void onStateChangedH(State state) {
@@ -769,9 +769,6 @@ public class VolumeDialog implements TunerService.Tunable {
                 && mState.ringerModeInternal == AudioManager.RINGER_MODE_SILENT;
         final boolean isZenAlarms = mState.zenMode == Global.ZEN_MODE_ALARMS;
         final boolean isZenNone = mState.zenMode == Global.ZEN_MODE_NO_INTERRUPTIONS;
-        final boolean isZenPriority = mState.zenMode == Global.ZEN_MODE_IMPORTANT_INTERRUPTIONS;
-        final boolean isRingZenNone = (isRingStream || isSystemStream) && isZenNone;
-        final boolean isRingLimited = isRingStream && isZenPriority;
         final boolean zenMuted = isZenAlarms ? (isRingStream || isSystemStream || isNotificationStream)
                 : isZenNone ? (isRingStream || isSystemStream || isAlarmStream || isMusicStream || isNotificationStream)
                 : isVibrate ? (isNotificationStream)


### PR DESCRIPTION
Fixes not disappearing cast pickers

* Commit 568585b introduced a new LinearLayout for the volume rows
* Remove unused booleans

Change-Id: I0660d10872cc1098fdd67b618a20ea0f8e926e68