### PR TITLE
Revert "[1/2] base: support separate encryption/lockscreen passwords"

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5123,14 +5123,6 @@ public final class Settings {
         public static final String LOCK_SCREEN_ALLOW_PRIVATE_NOTIFICATIONS =
                 "lock_screen_allow_private_notifications";
 
-
-        /**
-         * Separate password for encryption and the lockscreen.
-          * @hide
-         */
-        public static final String LOCK_SEPARATE_ENCRYPTION_PASSWORD =
-                "lock_separate_encryption_password";
-
         /**
          * When set by a user, allows notification remote input atop a securely locked screen
          * without having to unlock

--- a/core/java/com/android/internal/widget/LockPatternUtils.java
+++ b/core/java/com/android/internal/widget/LockPatternUtils.java
@@ -592,7 +592,7 @@ public class LockPatternUtils {
             // well, we tried...
         }
 
-        if (userHandle == UserHandle.USER_SYSTEM && !isSeparateEncryptionPasswordEnabled()) {
+        if (userHandle == UserHandle.USER_SYSTEM) {
             // Set the encryption password to default.
             updateEncryptionPassword(StorageManager.CRYPT_TYPE_DEFAULT, null);
             setCredentialRequiredToDecrypt(false);
@@ -650,8 +650,7 @@ public class LockPatternUtils {
 
             // Update the device encryption password.
             if (userId == UserHandle.USER_SYSTEM
-                    && LockPatternUtils.isDeviceEncryptionEnabled()
-                    && !isSeparateEncryptionPasswordEnabled()) {
+                    && LockPatternUtils.isDeviceEncryptionEnabled()) {
                 if (!shouldEncryptWithCredentials(true)) {
                     clearEncryptionPassword();
                 } else {
@@ -881,8 +880,7 @@ public class LockPatternUtils {
 
             // Update the device encryption password.
             if (userHandle == UserHandle.USER_SYSTEM
-                    && LockPatternUtils.isDeviceEncryptionEnabled()
-                    && !isSeparateEncryptionPasswordEnabled()) {
+                    && LockPatternUtils.isDeviceEncryptionEnabled()) {
                 if (!shouldEncryptWithCredentials(true)) {
                     clearEncryptionPassword();
                 } else {
@@ -1252,72 +1250,6 @@ public class LockPatternUtils {
         } catch (RemoteException e) {
             Log.e(TAG, "Error changing password visible state", e);
         }
-    }
-
-    private void updateEncryptionPasswordFromPassword(String password) {
-        if (!TextUtils.isEmpty(password)) {
-            int computedQuality = computePasswordQuality(password);
-            boolean numeric = computedQuality
-                == DevicePolicyManager.PASSWORD_QUALITY_NUMERIC;
-            boolean numericComplex = computedQuality
-                == DevicePolicyManager.PASSWORD_QUALITY_NUMERIC_COMPLEX;
-            int type = numeric || numericComplex ? StorageManager.CRYPT_TYPE_PIN
-                : StorageManager.CRYPT_TYPE_PASSWORD;
-            updateEncryptionPassword(type, password);
-        } else {
-            clearEncryptionPassword();
-        }
-    }
-
-    /**
-     * Set the encryption password separately from the lockscreen password.
-     *
-     * @param password The password to save
-     */
-    public void setSeparateEncryptionPassword(String password) {
-        updateEncryptionPasswordFromPassword(password);
-        setSeparateEncryptionPasswordEnabled(true);
-    }
-
-    /**
-     * Replace the separate encryption password by tying it to the lockscreen
-     * password. No change will occur if the provided lockscreen password is
-     * incorrect.
-     *
-     * @param password The current lockscreen password
-     * @return Whether the lockscreen password was correct.
-     */
-    public void replaceSeparateEncryptionPassword(String password) {
-        updateEncryptionPasswordFromPassword(password);
-        setSeparateEncryptionPasswordEnabled(false);
-    }
-
-    /**
-     * Replace the separate encryption password by tying it to the lockscreen
-     * pattern. No change will occur if the provided lockscreen password is
-     * incorrect.
-     *
-     * @param pattern The current lockscreen pattern
-     * @return Whether the lockscreen pattern was correct.
-     */
-    public void replaceSeparateEncryptionPasswordWithPattern(List<LockPatternView.Cell> pattern,
-            byte gridSize) {
-        String stringPattern = patternToString(pattern, gridSize);
-        updateEncryptionPassword(StorageManager.CRYPT_TYPE_PATTERN, stringPattern);
-        setSeparateEncryptionPasswordEnabled(false);
-    }
-
-    /**
-     * @return Whether the encryption password is separate from the lockscreen password.
-     */
-    public boolean isSeparateEncryptionPasswordEnabled() {
-        return getBoolean(Settings.Secure.LOCK_SEPARATE_ENCRYPTION_PASSWORD,
-                false, UserHandle.USER_SYSTEM);
-    }
-
-    private void setSeparateEncryptionPasswordEnabled(boolean enabled) {
-        setBoolean(Settings.Secure.LOCK_SEPARATE_ENCRYPTION_PASSWORD,
-                enabled, UserHandle.USER_SYSTEM);
     }
 
     /**

--- a/services/core/java/com/android/server/LockSettingsService.java
+++ b/services/core/java/com/android/server/LockSettingsService.java
@@ -1692,7 +1692,6 @@ public class LockSettingsService extends ILockSettings.Stub {
         Secure.LOCK_BIOMETRIC_WEAK_FLAGS,
         Secure.LOCK_PATTERN_VISIBLE,
         Secure.LOCK_PATTERN_TACTILE_FEEDBACK_ENABLED,
-        Secure.LOCK_SEPARATE_ENCRYPTION_PASSWORD,
         Secure.LOCK_PATTERN_SIZE,
         Secure.LOCK_DOTS_VISIBLE,
         Secure.LOCK_SHOW_ERROR_PATH,


### PR DESCRIPTION
This reverts commit 9d37d587aa2285513957fb204ce98856eafe797d.

Separated encryption password implementation is currently not so well implemented
and it exposes some additional security issues

Change-Id: I290491d6db445785aa750ac35b06e6524659af9f
Signed-off-by: Joey Rizzoli <joey@lineageos.org>