### PR TITLE
QS: Remove listeners only if added

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSTile.java
@@ -312,7 +312,9 @@ public abstract class QSTile<TState extends State> {
     protected abstract void setListening(boolean listening);
 
     protected void handleDestroy() {
-        setListening(false);
+        if (mListeners.size() != 0) {
+            setListening(false);
+        }
         mCallbacks.clear();
     }
 


### PR DESCRIPTION
handleDestroy() calls setListening(false) unconditionally. This
causes an error if no listener was never added. Check if we added
a listener and then try to remove it.

Change-Id: Iefe8aacbe87ba1c2c19c9e77cf132fc7c84798f9