### PR TITLE
Keyguard: Change fingerprint listening behavior

### DIFF
--- a/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -1175,7 +1175,7 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
                     com.android.keyguard.R.bool.config_fingerprintWakeAndUnlock)) {
                 return mKeyguardIsVisible || !mDeviceInteractive || mBouncer || mGoingToSleep;
             } else {
-                return mDeviceInteractive && (mKeyguardIsVisible || mBouncer);
+                return !mGoingToSleep && mDeviceInteractive && (mKeyguardIsVisible || mBouncer);
             }
         }
         return false;


### PR DESCRIPTION
* This patch affects devices that disable fingerprint
  wake-and-unlock via config_fingerprintWakeAndUnlock,
  and is mainly for fp scanners in the power button
* Don't listen to fingerprints when going to sleep
  to avoid a wakeup being triggered after pressing
  the power button to turn the screen off
* Fixes the following scenario:
 - Turn device on with not registered finger
 - Check time (or something on lock screen)
 - Use registered finger to turn off device,
   and leave finger on the scanner
 - Device screen turns off
 - Device wakes up at home screen

Change-Id: Ia40a6a763420cd716796515ddb9b816232218dc0