### PR TITLE
Don't disable the GPS prematurely

### DIFF
--- a/services/core/java/com/android/server/location/GnssLocationProvider.java
+++ b/services/core/java/com/android/server/location/GnssLocationProvider.java
@@ -1672,7 +1672,7 @@ public class GnssLocationProvider implements LocationProviderInterface {
         updateStatus(mStatus, usedInFixCount);
 
         if (mNavigating && mStatus == LocationProvider.AVAILABLE && mLastFixTime > 0 &&
-            System.currentTimeMillis() - mLastFixTime > RECENT_FIX_TIMEOUT) {
+            SystemClock.elapsedRealtime() - mLastFixTime > RECENT_FIX_TIMEOUT) {
             // send an intent to notify that the GPS is no longer receiving fixes.
             Intent intent = new Intent(LocationManager.GPS_FIX_CHANGE_ACTION);
             intent.putExtra(LocationManager.EXTRA_GPS_ENABLED, false);


### PR DESCRIPTION
Since commit b2b4489760230258d23f72f8f8dd643b09cd5b04
("Use SystemClock.elapsedRealtime() to calc TTFF") mLastFixTime
stores the time since boot rather than the current real time.

REGRESSION-1032

Change-Id: I39474a66c6d7dbd9ca0ff50a5a1b9c06007725c4