### PR TITLE
ZenModeHelper: Allow lights by default

### DIFF
--- a/services/core/java/com/android/server/notification/ZenModeHelper.java
+++ b/services/core/java/com/android/server/notification/ZenModeHelper.java
@@ -751,6 +751,8 @@ public class ZenModeHelper {
                 mAllowLights = CMSettings.System.getInt(mContext.getContentResolver(),
                    CMSettings.System.ZEN_PRIORITY_ALLOW_LIGHTS, 1) == 1;
                 break;
+            default:
+                mAllowLights = true;
         }
     }
 


### PR DESCRIPTION
mAllowLights is false by default, so if zen_mode is set to
ZEN_MODE_OFF, LED notifications will be suppressed. Ensure
mAllowLights is true when zen_mode is ZEN_MODE_OFF.

BUGBASH-1259

Change-Id: I979a4d9cfee4ee77c0cd3b9d6338d55961183eb7