### PR TITLE
Camera: Expose Aux camera to apps present in the whitelist

### DIFF
--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -21,6 +21,7 @@ import android.annotation.Nullable;
 import android.annotation.RequiresPermission;
 import android.annotation.SystemService;
 import android.content.Context;
+import android.hardware.Camera;
 import android.hardware.CameraInfo;
 import android.hardware.CameraStatus;
 import android.hardware.ICameraService;
@@ -841,6 +842,7 @@ public final class CameraManager {
 
                 int idCount = 0;
                 for (int i = 0; i < mDeviceStatus.size(); i++) {
+                    if ((i == 2) && !Camera.shouldExposeAuxCamera()) break;
                     int status = mDeviceStatus.valueAt(i);
                     if (status == ICameraServiceListener.STATUS_NOT_PRESENT ||
                             status == ICameraServiceListener.STATUS_ENUMERATING) continue;
@@ -849,6 +851,7 @@ public final class CameraManager {
                 cameraIds = new String[idCount];
                 idCount = 0;
                 for (int i = 0; i < mDeviceStatus.size(); i++) {
+                    if ((i == 2) && !Camera.shouldExposeAuxCamera()) break;
                     int status = mDeviceStatus.valueAt(i);
                     if (status == ICameraServiceListener.STATUS_NOT_PRESENT ||
                             status == ICameraServiceListener.STATUS_ENUMERATING) continue;
@@ -985,6 +988,16 @@ public final class CameraManager {
         }
 
         private void onStatusChangedLocked(int status, String id) {
+            /* Force to ignore the last mono/aux camera status update
+             * if the package name does not falls in this bucket
+             */
+            if (!Camera.shouldExposeAuxCamera()) {
+                if (Integer.parseInt(id) >= 2) {
+                    Log.w(TAG, "[soar.cts] ignore the status update of camera: " + id);
+                    return;
+                }
+            }
+
             if (DEBUG) {
                 Log.v(TAG,
                         String.format("Camera id %s has status changed to 0x%x", id, status));

--- a/core/jni/android_hardware_Camera.cpp
+++ b/core/jni/android_hardware_Camera.cpp
@@ -1101,7 +1101,7 @@ static void android_hardware_Camera_sendVendorCommand(JNIEnv *env, jobject thiz,
 //-------------------------------------------------
 
 static const JNINativeMethod camMethods[] = {
-  { "getNumberOfCameras",
+  { "native_getNumberOfCameras",
     "()I",
     (void *)android_hardware_Camera_getNumberOfCameras },
   { "_getCameraInfo",


### PR DESCRIPTION
Issue:
3rd party apk cannot handle additional aux camera and may cause crash,
Mono camera doesnt support all capabilities of HAL3 causing CTS issue.

Fix:
1. Expose aux camera to apps present in the whitelist
2. ignore the availabe/unavailable status update for aux camera
3. returning exception for open request for bad cameraid

Change-Id: I15910154c6df205e6d4e00bfad30a00c9e3d5bee
CRs-Fixed: 1086937