### PR TITLE
PackageManager: Don't dereference mPlatfromPackage until available

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -9259,13 +9259,13 @@ public class PackageManagerService extends IPackageManager.Stub
                   mVendorPlatformSignatures) == PackageManager.SIGNATURE_MATCH) {
                 // Overwrite package signature with our platform signature
                 // if the signature is the vendor's platform signature
-                pkg.mSignatures = mPlatformPackage.mSignatures;
-                SELinuxMMAC.assignSeInfoValue(pkg);
+                if (mPlatformPackage != null) {
+                    pkg.mSignatures = mPlatformPackage.mSignatures;
+                    SELinuxMMAC.assignSeInfoValue(pkg);
+                }
             }
         } catch (PackageParserException e) {
             throw PackageManagerException.from(e);
-        } catch (NullPointerException e) {
-            throw new PackageManagerException(e.getMessage());
         } finally {
             Trace.traceEnd(TRACE_TAG_PACKAGE_MANAGER);
         }


### PR DESCRIPTION
* mPlatformPackage is not set until later in the package parsing
  process. Avoid the NPE instead of catching it, as it leaves
  packages unparsed.

Change-Id: Ib88a7e4e3f723288ad435d79b1b68d6d3fcb48c2