### PR TITLE
SystemUI: Dismiss keyguard on boot if disabled by current profile

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -1319,6 +1319,8 @@ public class KeyguardViewMediator extends SystemUI {
             if (isKeyguardDisabled(KeyguardUpdateMonitor.getCurrentUser())
                     && !lockedOrMissing && !forceShow) {
                 if (DEBUG) Log.d(TAG, "doKeyguard: not showing because lockscreen is off");
+                setShowingLocked(false);
+                hideLocked();
                 return;
             }
 


### PR DESCRIPTION
Properly dismiss keyguard on boot if the current profile has it
disabled, otherwise we will just show a black screen with just the
status bar and a navbar with only the back button.

BUGBASH-87

Change-Id: I14ed10ae9db40c32be22c1fb43f8a1719787d91b