### PR TITLE
SystemUI: Fix alignment glitch with brightness mirror

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
@@ -90,6 +90,7 @@ public class QSPanel extends LinearLayout implements Tunable, Callback, Brightne
     private Record mDetailRecord;
 
     private BrightnessMirrorController mBrightnessMirrorController;
+    private ImageView mMirrorAutoBrightnessView;
     private View mDivider;
 
     public QSPanel(Context context) {
@@ -200,6 +201,10 @@ public class QSPanel extends LinearLayout implements Tunable, Callback, Brightne
         } else if (QS_SHOW_AUTO_BRIGHTNESS.equals(key) && mIsAutomaticBrightnessAvailable) {
             mAutoBrightnessView.setVisibility(newValue == null || Integer.parseInt(newValue) != 0
                     ? VISIBLE : GONE);
+            if (mMirrorAutoBrightnessView != null) {
+                mMirrorAutoBrightnessView.setVisibility(newValue == null ||
+                        Integer.parseInt(newValue) != 0 ? INVISIBLE : GONE);
+            }
         }
     }
 
@@ -285,6 +290,10 @@ public class QSPanel extends LinearLayout implements Tunable, Callback, Brightne
             ToggleSliderView brightnessSlider = findViewById(R.id.brightness_slider);
             ToggleSliderView mirrorSlider = mBrightnessMirrorController.getMirror()
                     .findViewById(R.id.brightness_slider);
+            mMirrorAutoBrightnessView = mBrightnessMirrorController.getMirror()
+                    .findViewById(R.id.brightness_icon);
+            mMirrorAutoBrightnessView.setVisibility(mAutoBrightnessView.getVisibility()
+                    == View.VISIBLE ? View.INVISIBLE : View.GONE);
             brightnessSlider.setMirror(mirrorSlider);
             brightnessSlider.setMirrorController(mBrightnessMirrorController);
         }


### PR DESCRIPTION
Alignment of brightness mirror dialog was not exatly same as the
QS brightness dialog, which produced a visual glitch of slider
thumb shifting whenever we change brightness.
This is solved by dynamically handling the visibility of
mirror brightness icon, gone when brightness icon is off and
invisible when brightness icon is on, so that both mirror and
QS slider are equally aligned.

Change-Id: Ifb85643db669ee8d7473d3c48e7e4733428a77d6