### PR TITLE
Add an option to force pre-O apps to use full screen aspect ratio

### DIFF
--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -412,6 +412,8 @@ import com.android.server.vr.VrManagerInternal;
 import com.android.server.wm.PinnedStackWindowController;
 import com.android.server.wm.WindowManagerService;
 
+import org.lineageos.internal.applications.LineageActivityManager;
+
 import java.text.SimpleDateFormat;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -1736,6 +1738,9 @@ public class ActivityManagerService extends IActivityManager.Stub
     final boolean mPermissionReviewRequired;
 
     private static String sTheRealBuildSerial = Build.UNKNOWN;
+
+    // Lineage sdk activity related helper
+    private LineageActivityManager mLineageActivityManager;
 
     /**
      * Current global configuration information. Contains general settings for the entire system,
@@ -12221,6 +12226,10 @@ public class ActivityManagerService extends IActivityManager.Stub
         RescueParty.onSettingsProviderPublished(mContext);
 
         //mUsageStatsService.monitorPackages();
+
+        // LineageActivityManager depends on settings so we can initialize only
+        // after providers are available.
+        mLineageActivityManager = new LineageActivityManager(mContext);
     }
 
     private void startPersistentApps(int matchFlags) {
@@ -24747,5 +24756,9 @@ public class ActivityManagerService extends IActivityManager.Stub
                 Binder.restoreCallingIdentity(origId);
             }
         }
+    }
+
+    public boolean shouldForceLongScreen(String packageName) {
+        return mLineageActivityManager.shouldForceLongScreen(packageName);
     }
 }

--- a/services/core/java/com/android/server/am/ActivityRecord.java
+++ b/services/core/java/com/android/server/am/ActivityRecord.java
@@ -2334,7 +2334,9 @@ final class ActivityRecord extends ConfigurationContainer implements AppWindowCo
         int maxActivityWidth = containingAppWidth;
         int maxActivityHeight = containingAppHeight;
 
-        if (containingAppWidth < containingAppHeight) {
+        if (service.shouldForceLongScreen(packageName)) {
+            // Use containingAppWidth/Height for maxActivityWidth/Height when force long screen
+        } else if (containingAppWidth < containingAppHeight) {
             // Width is the shorter side, so we use that to figure-out what the max. height
             // should be given the aspect ratio.
             maxActivityHeight = (int) ((maxActivityWidth * maxAspectRatio) + 0.5f);


### PR DESCRIPTION
When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change aspect ratio
for pre-O apps to full screen aspect ratio.

Change-Id: I41d5408841593a12443be885e11959bffaebb67b