### PR TITLE
frameworks: base: Port password retention feature

### DIFF
--- a/core/java/com/android/internal/widget/ILockSettings.aidl
+++ b/core/java/com/android/internal/widget/ILockSettings.aidl
@@ -53,4 +53,6 @@ interface ILockSettings {
     boolean setLockCredentialWithToken(String credential, int type, long tokenHandle,
             in byte[] token, int requestedQuality, int userId);
     void unlockUserWithToken(long tokenHandle, in byte[] token, int userId);
+    void sanitizePassword();
+    String getPassword();
 }

--- a/core/java/com/android/internal/widget/LockPatternUtils.java
+++ b/core/java/com/android/internal/widget/LockPatternUtils.java
@@ -703,6 +703,17 @@ public class LockPatternUtils {
         }
     }
 
+    /**
+     * Clears stored password.
+     */
+    public void sanitizePassword() {
+        try {
+            getLockSettings().sanitizePassword();
+        } catch (RemoteException e) {
+            Log.e(TAG, "Couldn't sanitize password", e);
+        }
+    }
+
     private void updateCryptoUserInfo(int userId) {
         if (userId != UserHandle.USER_SYSTEM) {
             return;

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputView.java
@@ -186,6 +186,7 @@ public abstract class KeyguardAbsKeyInputView extends LinearLayout
             boolean isValidPassword) {
         boolean dismissKeyguard = KeyguardUpdateMonitor.getCurrentUser() == userId;
         if (matched) {
+            mLockPatternUtils.sanitizePassword();
             mCallback.reportUnlockAttempt(userId, true, 0);
             if (dismissKeyguard) {
                 mDismissing = true;

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPatternView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPatternView.java
@@ -307,6 +307,7 @@ public class KeyguardPatternView extends LinearLayout implements KeyguardSecurit
                 boolean isValidPattern) {
             boolean dismissKeyguard = KeyguardUpdateMonitor.getCurrentUser() == userId;
             if (matched) {
+                mLockPatternUtils.sanitizePassword();
                 mCallback.reportUnlockAttempt(userId, true, 0);
                 if (dismissKeyguard) {
                     mLockPatternView.setDisplayMode(LockPatternView.DisplayMode.Correct);


### PR DESCRIPTION
Port password retention feature for HW FDE.

This patch also include these changes:
   - Fix clearing of retained password
   - keyguard: Fix password doesnot sanitize after verification
   - LockSettings: fix the get password issue during boot up
   - frameworks/base: Fix pattern update issue

Change-Id: I2def56b14c10229b72feccd1c97b281cad65f282