### PR TITLE
SystemUI: CellularTile: Don't call showDetail() when device is locked

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/CellularTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/CellularTile.java
@@ -142,6 +142,12 @@ public class CellularTile extends QSTileImpl<SignalState> {
     @Override
     protected void handleSecondaryClick() {
         if (mDataController.isMobileDataSupported()) {
+            if (mKeyguardMonitor.isSecure() && !mKeyguardMonitor.canSkipBouncer()) {
+                mActivityStarter.postQSRunnableDismissingKeyguard(() -> {
+                    showDetail(true);
+                });
+                return;
+            }
             showDetail(true);
         } else {
             mActivityStarter


### PR DESCRIPTION
* We recently enabled dualTarget for CellularTile which allowed us
  to toggle mobile data without unlocking device. Moving showDetail
  call to postQSRunnableDismissingKeyguard when the device is locked
  fixes this issue.

Change-Id: I16dc766166a33a309a2fc945e81fa15b5d194196