### PR TITLE
base: limit direct share targets to reduce lag

### DIFF
--- a/core/java/com/android/internal/app/ChooserActivity.java
+++ b/core/java/com/android/internal/app/ChooserActivity.java
@@ -99,7 +99,7 @@ public class ChooserActivity extends ResolverActivity {
 
     private static final boolean DEBUG = false;
 
-    private static final int QUERY_TARGET_SERVICE_LIMIT = 5;
+    private static final int QUERY_TARGET_SERVICE_LIMIT = 3;
     private static final int WATCHDOG_TIMEOUT_MILLIS = 2000;
 
     private Bundle mReplacementExtras;
@@ -927,8 +927,8 @@ public class ChooserActivity extends ResolverActivity {
         public static final int TARGET_SERVICE = 1;
         public static final int TARGET_STANDARD = 2;
 
-        private static final int MAX_SERVICE_TARGETS = 8;
-        private static final int MAX_TARGETS_PER_SERVICE = 4;
+        private static final int MAX_SERVICE_TARGETS = 4;
+        private static final int MAX_TARGETS_PER_SERVICE = 2;
 
         private final List<ChooserTargetInfo> mServiceTargets = new ArrayList<>();
         private final List<TargetInfo> mCallerTargets = new ArrayList<>();


### PR DESCRIPTION
Limit target packages and services query to reduce lag
when opening the share menu

Change-Id: I00179a87132d5d186b9482e0b6424eae0d175fbd
Signed-off-by: Joey <joey@lineageos.org>