### PR TITLE
Add support for the .opus file format

### DIFF
--- a/media/java/android/media/MediaFile.java
+++ b/media/java/android/media/MediaFile.java
@@ -199,6 +199,7 @@ public class MediaFile {
         addFileType("OGG", FILE_TYPE_OGG, "audio/ogg", MtpConstants.FORMAT_OGG, false);
         addFileType("OGG", FILE_TYPE_OGG, "application/ogg", MtpConstants.FORMAT_OGG, true);
         addFileType("OGA", FILE_TYPE_OGG, "application/ogg", MtpConstants.FORMAT_OGG, false);
+        addFileType("OPUS", FILE_TYPE_OGG, "audio/ogg", MtpConstants.FORMAT_OGG, false);
         addFileType("AAC", FILE_TYPE_AAC, "audio/aac", MtpConstants.FORMAT_AAC, true);
         addFileType("AAC", FILE_TYPE_AAC, "audio/aac-adts", MtpConstants.FORMAT_AAC, false);
         addFileType("MKA", FILE_TYPE_MKA, "audio/x-matroska");

--- a/services/core/java/com/android/server/storage/FileCollector.java
+++ b/services/core/java/com/android/server/storage/FileCollector.java
@@ -78,6 +78,7 @@ public class FileCollector {
         EXTENSION_MAP.put("wav", AUDIO);
         EXTENSION_MAP.put("ogg", AUDIO);
         EXTENSION_MAP.put("oga", AUDIO);
+        EXTENSION_MAP.put("opus", AUDIO);
         // Video
         EXTENSION_MAP.put("3gpp", VIDEO);
         EXTENSION_MAP.put("3gp", VIDEO);


### PR DESCRIPTION
The codec and container format are already supported, but not in that
combination. Simply add the file extension as a type of Ogg file (which
it is).

Change-Id: Ia9134a8d1205f73da12f579b3ad62367b2b8d88e
See: https://issuetracker.google.com/issues/37054258