### PR TITLE
SystemUI: Fix default mShowDpadArrowKeys value

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
@@ -1171,7 +1171,7 @@ public class NavigationBarView extends FrameLayout implements PluginListener<Nav
     @Override
     public void onTuningChanged(String key, String newValue) {
         if (NAVIGATION_BAR_MENU_ARROW_KEYS.equals(key)) {
-            mShowDpadArrowKeys = newValue == null || Integer.parseInt(newValue) == 1;
+            mShowDpadArrowKeys = newValue != null && Integer.parseInt(newValue) != 0;
             setNavigationIconHints(mNavigationIconHints);
         }
     }


### PR DESCRIPTION
* On clean installations this would end up being
  initialized to invalid value. Changing this
  into v != null && v != 0 check, which matches
  other SystemUI tuning checks fixes this issue.

Change-Id: I9b0e000f15a39f71788259e4db962d04b7f8f0c9