### PR TITLE
SystemUI: Fix too big spacing between QS icons in landscape on sw600dp

### DIFF
--- a/packages/SystemUI/res/values-sw600dp/dimens.xml
+++ b/packages/SystemUI/res/values-sw600dp/dimens.xml
@@ -16,6 +16,9 @@
 */
 -->
 <resources>
+    <!-- Width for the spacer, used between QS tiles. -->
+    <dimen name="qs_quick_tile_space_width">0dp</dimen>
+
     <!-- Standard notification width + gravity -->
     <dimen name="notification_panel_width">@dimen/standard_notification_panel_width</dimen>
 


### PR DESCRIPTION
Change-Id: I047453c169854636d9e179d4678b94c7724bb854