### PR TITLE
Binder: Fix improper JNI call for dumpProxyDebugInfo

### DIFF
--- a/core/jni/android_util_Binder.cpp
+++ b/core/jni/android_util_Binder.cpp
@@ -1010,8 +1010,8 @@ static void android_os_BinderInternal_proxyLimitcallback(int uid)
     {
         // Calls into BinderProxy must be serialized
         AutoMutex _l(gProxyLock);
-        env->CallStaticObjectMethod(gBinderProxyOffsets.mClass,
-                                    gBinderProxyOffsets.mDumpProxyDebugInfo);
+        env->CallStaticVoidMethod(gBinderProxyOffsets.mClass,
+                                  gBinderProxyOffsets.mDumpProxyDebugInfo);
     }
     if (env->ExceptionCheck()) {
         ScopedLocalRef<jthrowable> excep(env, env->ExceptionOccurred());


### PR DESCRIPTION
 * dumpProxyDebugInfo doesn't have a return value, so it should be
   invoked via CallStaticVoidMethod instead of CallStaticObjectMethod.

Change-Id: Ie4c497f69b371ec3d55e7736827f73142d14a5b4