### PR TITLE
StatusBarSignalPolicy: Fix missing provisioned in equals and copyTo

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarSignalPolicy.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarSignalPolicy.java
@@ -446,6 +446,7 @@ public class StatusBarSignalPolicy implements NetworkControllerImpl.SignalCallba
                     typeId == that.typeId &&
                     roaming == that.roaming &&
                     needsLeadingPadding == that.needsLeadingPadding &&
+                    provisioned == that.provisioned &&
                     Objects.equals(typeContentDescription, that.typeContentDescription);
         }
 
@@ -471,6 +472,7 @@ public class StatusBarSignalPolicy implements NetworkControllerImpl.SignalCallba
             other.typeId = typeId;
             other.roaming = roaming;
             other.needsLeadingPadding = needsLeadingPadding;
+            other.provisioned = provisioned;
             other.typeContentDescription = typeContentDescription;
         }
 


### PR DESCRIPTION
* equals and copyTo should include all MobileIconState properties
* therefore, add the newly introduced boolean, provisioned

Change-Id: Ic810bbe7538506612f86695ce520e8b9542bc634