### PR TITLE
audio: Don't play sound effects if stream is muted

### DIFF
--- a/services/core/java/com/android/server/audio/AudioService.java
+++ b/services/core/java/com/android/server/audio/AudioService.java
@@ -5606,7 +5606,11 @@ public class AudioService extends IAudioService.Stub
                     break;
 
                 case MSG_PLAY_SOUND_EFFECT:
-                    onPlaySoundEffect(msg.arg1, msg.arg2);
+                    if (isStreamMute(AudioSystem.STREAM_SYSTEM)) {
+                        Log.d(TAG, "Stream muted, skip playback");
+                    } else {
+                        onPlaySoundEffect(msg.arg1, msg.arg2);
+                    }
                     break;
 
                 case MSG_BTA2DP_DOCK_TIMEOUT:


### PR DESCRIPTION
 * Stop turning on the audio hardware and playing silence.
 * Kind of annoying with certain types of Bluetooth headphones
   that don't actually play silence very well (hissssssssss).
   Not to mention power usage.

Change-Id: I6985db8710f8b0f61619ac57e8efb9e4e01cc31a
(cherry picked from commit 0e8a502ff119d285fdbbf521c45213b0b42b3d6f)