### PR TITLE
PhoneWindowManager: Fix screen peek KEY_FOCUS handling

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -6852,7 +6852,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     // Check if screen is fully on before letting the device go to sleep
                     if (mScreenOnFully && mIsFocusPressed) {
                         mPowerManager.goToSleep(SystemClock.uptimeMillis());
-                    } else {
+                    } else if (!interactive && mCameraSleepOnRelease) {
                         mFocusReleasedGoToSleep = true;
                     }
                     mIsFocusPressed = false;


### PR DESCRIPTION
* This addresses following issues where screen gets
  turned back off after turning it on:
  - User has screen peek disabled and presses KEY_FOCUS
    while their device is locked and screen is off.
  - User has screen peek enabled and presses KEY_FOCUS
    while their device is unlocked and screen is on
    then locks their device.

Change-Id: I92abc3c54747de3cc480ccd748885d80ba4a343a