### PR TITLE
SystemUI: Bring back lockscreen tuner (1/2)

### DIFF
--- a/packages/SystemUI/LineageManifest.xml
+++ b/packages/SystemUI/LineageManifest.xml
@@ -65,6 +65,20 @@
         </activity-alias>
 
         <activity-alias
+            android:name=".tuner.LockscreenFragment"
+            android:targetActivity=".tuner.TunerActivity"
+            android:icon="@drawable/tuner"
+            android:theme="@style/TunerSettings"
+            android:label="@string/tuner_lock_screen"
+            android:process=":tuner"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.android.settings.action.LOCK_SCREEN_TUNER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity-alias>
+
+        <activity-alias
             android:name=".tuner.TunerActivity"
             android:targetActivity=".tuner.TunerActivity"
             android:icon="@drawable/tuner"

--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -95,4 +95,7 @@
 
     <!-- Button that controls inversion of layout of navigation bar -->
     <string name="nav_bar_layout_inverse">Invert layout</string>
+
+    <!-- Hint for custom lockscreen shortcuts -->
+    <string name="custom_swipe_hint">Swipe from icon for <xliff:g name="target">%s</xliff:g></string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
@@ -23,6 +23,8 @@ import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_LEFT_BUTT
 import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_LEFT_UNLOCK;
 import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_RIGHT_BUTTON;
 import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_RIGHT_UNLOCK;
+import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_SHORTCUT_CAMERA;
+import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_SHORTCUT_VOICE_ASSIST;
 
 import android.app.ActivityManager;
 import android.app.ActivityOptions;
@@ -162,9 +164,11 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
 
     private IntentButton mRightButton = new DefaultRightButton();
     private Extension<IntentButton> mRightExtension;
+    private CharSequence mRightButtonTarget;
     private String mRightButtonStr;
     private IntentButton mLeftButton = new DefaultLeftButton();
     private Extension<IntentButton> mLeftExtension;
+    private CharSequence mLeftButtonTarget;
     private String mLeftButtonStr;
     private LockscreenGestureLogger mLockscreenGestureLogger = new LockscreenGestureLogger();
     private boolean mDozing;
@@ -248,7 +252,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
                 R.dimen.keyguard_indication_margin_bottom_ambient);
         mBurnInYOffset = getResources().getDimensionPixelSize(
                 R.dimen.charging_indication_burn_in_prevention_offset_y);
-        updateCameraVisibility();
+        updateRightAffordanceIcon();
         mUnlockMethodCache = UnlockMethodCache.getInstance(getContext());
         mUnlockMethodCache.addListener(this);
         KeyguardUpdateMonitor updateMonitor = KeyguardUpdateMonitor.getInstance(mContext);
@@ -358,6 +362,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
 
     private void updateRightAffordanceIcon() {
         IconState state = mRightButton.getIcon();
+        mRightButtonTarget = state.contentDescription;
         mRightAffordanceView.setVisibility(!mDozing && state.isVisible ? View.VISIBLE : View.GONE);
         mRightAffordanceView.setImageDrawable(state.drawable, state.tint);
         mRightAffordanceView.setContentDescription(state.contentDescription);
@@ -365,7 +370,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
 
     public void setStatusBar(StatusBar statusBar) {
         mStatusBar = statusBar;
-        updateCameraVisibility(); // in case onFinishInflate() was called too early
+        refreshAffordance(); // in case onFinishInflate() was called too early
     }
 
     public void setAffordanceHelper(KeyguardAffordanceHelper affordanceHelper) {
@@ -374,8 +379,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
 
     public void setUserSetupComplete(boolean userSetupComplete) {
         mUserSetupComplete = userSetupComplete;
-        updateCameraVisibility();
-        updateLeftAffordanceIcon();
+        refreshAffordance();
     }
 
     private Intent getCameraIntent() {
@@ -391,13 +395,30 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
                 KeyguardUpdateMonitor.getCurrentUser());
     }
 
-    private void updateCameraVisibility() {
-        if (mRightAffordanceView == null) {
-            // Things are not set up yet; reply hazy, ask again later
-            return;
+    /**
+     * Refreshes affordance buttons, to let
+     *   - Left affordance switch between Phone <-> Voice shortcuts
+     *   - Camera button disappear/appear if it's unavailable/available
+     *   - Custom shortcuts finish it's loading - this is the reason of checking their visibility
+     */
+    private void refreshAffordance() {
+        if (mRightAffordanceView != null) {
+            if (mRightButton instanceof DefaultRightButton) {
+                updateRightAffordanceIcon();
+            } else if (mRightAffordanceView.getVisibility() != View.VISIBLE) {
+                // Also includes inflating preview
+                setRightButton(mRightButton);
+            }
         }
-        mRightAffordanceView.setVisibility(!mDozing && mRightButton.getIcon().isVisible
-                ? View.VISIBLE : View.GONE);
+
+        if (mLeftAffordanceView != null) {
+            if (mLeftButton instanceof DefaultLeftButton) {
+                updateLeftAffordanceIcon();
+            } else if (mLeftAffordanceView.getVisibility() != View.VISIBLE) {
+                // Also includes inflating preview
+                updateLeftAffordance();
+            }
+        }
     }
 
     /**
@@ -410,6 +431,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
 
     private void updateLeftAffordanceIcon() {
         IconState state = mLeftButton.getIcon();
+        mLeftButtonTarget = state.contentDescription;
         mLeftAffordanceView.setVisibility(!mDozing && state.isVisible ? View.VISIBLE : View.GONE);
         mLeftAffordanceView.setImageDrawable(state.drawable, state.tint);
         mLeftAffordanceView.setContentDescription(state.contentDescription);
@@ -627,7 +649,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         super.onVisibilityChanged(changedView, visibility);
         if (changedView == this && visibility == VISIBLE) {
             mLockIcon.update();
-            updateCameraVisibility();
+            refreshAffordance();
         }
     }
 
@@ -663,7 +685,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
     @Override
     public void onUnlockMethodStateChanged() {
         mLockIcon.update();
-        updateCameraVisibility();
+        refreshAffordance();
     }
 
     private void inflateCameraPreview() {
@@ -733,7 +755,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
             post(new Runnable() {
                 @Override
                 public void run() {
-                    updateCameraVisibility();
+                    refreshAffordance();
                 }
             });
         }
@@ -743,7 +765,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
             new KeyguardUpdateMonitorCallback() {
                 @Override
                 public void onUserSwitchComplete(int userId) {
-                    updateCameraVisibility();
+                    refreshAffordance();
                 }
 
                 @Override
@@ -784,8 +806,8 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
                 @Override
                 public void onUserUnlocked() {
                     inflateCameraPreview();
-                    updateCameraVisibility();
-                    updateLeftAffordance();
+                    refreshAffordance();
+                    updateLeftPreview();
                 }
             };
 
@@ -804,15 +826,35 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         inflateCameraPreview();
     }
 
+    public CharSequence getShortcutTargetName(boolean rightIcon){
+        if (rightIcon) {
+            return mRightButtonTarget;
+        } else {
+            return mLeftButtonTarget;
+        }
+    }
+
+    private IntentButton translateTunerButton(IntentButton button) {
+        IconState buttonIcon = button.getIcon();
+
+        if (!buttonIcon.isVisible) {
+            if (buttonIcon.contentDescription.equals(LOCKSCREEN_SHORTCUT_CAMERA)) {
+                return new DefaultRightButton(true);
+            } else if (buttonIcon.contentDescription.equals(LOCKSCREEN_SHORTCUT_VOICE_ASSIST)) {
+                return new DefaultLeftButton(true);
+            }
+        }
+        return button;
+    }
+
     private void setRightButton(IntentButton button) {
-        mRightButton = button;
+        mRightButton = translateTunerButton(button);
         updateRightAffordanceIcon();
-        updateCameraVisibility();
         inflateCameraPreview();
     }
 
     private void setLeftButton(IntentButton button) {
-        mLeftButton = button;
+        mLeftButton = translateTunerButton(button);
         if (!(mLeftButton instanceof DefaultLeftButton)) {
             mLeftIsVoiceAssist = false;
         }
@@ -822,8 +864,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
     public void setDozing(boolean dozing, boolean animate) {
         mDozing = dozing;
 
-        updateCameraVisibility();
-        updateLeftAffordanceIcon();
+        refreshAffordance();
 
         if (dozing) {
             mLockIcon.setVisibility(INVISIBLE);
@@ -857,12 +898,22 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
     private class DefaultLeftButton implements IntentButton {
 
         private IconState mIconState = new IconState();
+        private boolean mForceVisibility;
+
+        public DefaultLeftButton(boolean forceVisibility) {
+            mForceVisibility = forceVisibility;
+        }
+
+        public DefaultLeftButton() {
+            this(false);
+        }
 
         @Override
         public IconState getIcon() {
             mLeftIsVoiceAssist = canLaunchVoiceAssist();
             final boolean showAffordance =
-                    getResources().getBoolean(R.bool.config_keyguardShowLeftAffordance);
+                    getResources().getBoolean(R.bool.config_keyguardShowLeftAffordance) ||
+                            mForceVisibility;
             if (mLeftIsVoiceAssist) {
                 mIconState.isVisible = mUserSetupComplete && showAffordance;
                 if (mLeftAssistIcon == null) {
@@ -890,14 +941,25 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
     private class DefaultRightButton implements IntentButton {
 
         private IconState mIconState = new IconState();
+        private boolean mForceVisibility;
+
+        public DefaultRightButton(boolean forceVisibility) {
+            mForceVisibility = forceVisibility;
+        }
+
+        public DefaultRightButton() {
+            this(false);
+        }
 
         @Override
         public IconState getIcon() {
             ResolveInfo resolved = resolveCameraIntent();
             boolean isCameraDisabled = (mStatusBar != null) && !mStatusBar.isCameraAllowedByAdmin();
+            final boolean showAffordance =
+                    getResources().getBoolean(R.bool.config_keyguardShowCameraAffordance) ||
+                            mForceVisibility;
             mIconState.isVisible = !isCameraDisabled && resolved != null
-                    && getResources().getBoolean(R.bool.config_keyguardShowCameraAffordance)
-                    && mUserSetupComplete;
+                    && showAffordance && mUserSetupComplete;
             mIconState.drawable = mContext.getDrawable(R.drawable.ic_camera_alt_24dp);
             mIconState.contentDescription =
                     mContext.getString(R.string.accessibility_camera_button);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -36,6 +36,7 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.os.PowerManager;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.FloatProperty;
 import android.util.Log;
@@ -2186,13 +2187,20 @@ public class NotificationPanelView extends PanelView implements
             }
         });
         rightIcon = getLayoutDirection() == LAYOUT_DIRECTION_RTL ? !rightIcon : rightIcon;
+
+        // Create swipe hint with app name. If it's empty, event calls below will use default hints
+        CharSequence hint = mKeyguardBottomArea.getShortcutTargetName(rightIcon);
+        if (!TextUtils.isEmpty(hint)) {
+            hint = mContext.getString(R.string.custom_swipe_hint, hint);
+        }
+
         if (rightIcon) {
-            mStatusBar.onCameraHintStarted();
+            mStatusBar.onCameraHintStarted(hint);
         } else {
             if (mKeyguardBottomArea.isLeftVoiceAssist()) {
-                mStatusBar.onVoiceAssistHintStarted();
+                mStatusBar.onVoiceAssistHintStarted(hint);
             } else {
-                mStatusBar.onPhoneHintStarted();
+                mStatusBar.onPhoneHintStarted(hint);
             }
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -4416,19 +4416,22 @@ public class StatusBar extends SystemUI implements DemoMode, TunerService.Tunabl
         mKeyguardIndicationController.hideTransientIndicationDelayed(HINT_RESET_DELAY_MS);
     }
 
-    public void onCameraHintStarted() {
+    public void onCameraHintStarted(CharSequence hint) {
         mFalsingManager.onCameraHintStarted();
-        mKeyguardIndicationController.showTransientIndication(R.string.camera_hint);
+        hint = (TextUtils.isEmpty(hint) ? mContext.getString(R.string.camera_hint) : hint);
+        mKeyguardIndicationController.showTransientIndication(hint);
     }
 
-    public void onVoiceAssistHintStarted() {
+    public void onVoiceAssistHintStarted(CharSequence hint) {
         mFalsingManager.onLeftAffordanceHintStarted();
-        mKeyguardIndicationController.showTransientIndication(R.string.voice_hint);
+        hint = (TextUtils.isEmpty(hint) ? mContext.getString(R.string.voice_hint) : hint);
+        mKeyguardIndicationController.showTransientIndication(hint);
     }
 
-    public void onPhoneHintStarted() {
+    public void onPhoneHintStarted(CharSequence hint) {
         mFalsingManager.onLeftAffordanceHintStarted();
-        mKeyguardIndicationController.showTransientIndication(R.string.phone_hint);
+        hint = (TextUtils.isEmpty(hint) ? mContext.getString(R.string.phone_hint) : hint);
+        mKeyguardIndicationController.showTransientIndication(hint);
     }
 
     public void onTrackingStopped(boolean expand) {

--- a/packages/SystemUI/src/com/android/systemui/tuner/LockscreenFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/LockscreenFragment.java
@@ -25,6 +25,7 @@ import android.content.pm.LauncherApps;
 import android.content.pm.LauncherApps.ShortcutQuery;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ShortcutInfo;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.ScaleDrawable;
 import android.os.Bundle;
@@ -72,6 +73,9 @@ public class LockscreenFragment extends PreferenceFragment {
     public static final String LOCKSCREEN_LEFT_UNLOCK = "sysui_keyguard_left_unlock";
     public static final String LOCKSCREEN_RIGHT_BUTTON = "sysui_keyguard_right";
     public static final String LOCKSCREEN_RIGHT_UNLOCK = "sysui_keyguard_right_unlock";
+    public static final String LOCKSCREEN_SHORTCUT_CAMERA = "c";
+    public static final String LOCKSCREEN_SHORTCUT_NONE = "n";
+    public static final String LOCKSCREEN_SHORTCUT_VOICE_ASSIST = "v";
 
     private final ArrayList<Tunable> mTunables = new ArrayList<>();
     private TunerService mTunerService;
@@ -96,7 +100,7 @@ public class LockscreenFragment extends PreferenceFragment {
         Preference shortcut = findPreference(buttonSetting);
         SwitchPreference unlock = (SwitchPreference) findPreference(unlockKey);
         addTunable((k, v) -> {
-            boolean visible = !TextUtils.isEmpty(v);
+            boolean visible = !TextUtils.isEmpty(v) && (v.contains("/") || v.contains("::"));
             unlock.setVisible(visible);
             setSummary(shortcut, v);
         }, buttonSetting);
@@ -129,6 +133,10 @@ public class LockscreenFragment extends PreferenceFragment {
             ActivityInfo info = getActivityinfo(getContext(), value);
             shortcut.setSummary(info != null ? info.loadLabel(getContext().getPackageManager())
                     : null);
+        } else if (value.equals(LOCKSCREEN_SHORTCUT_VOICE_ASSIST)) {
+            shortcut.setSummary(R.string.accessibility_voice_assist_button);
+        } else if (value.equals(LOCKSCREEN_SHORTCUT_CAMERA)) {
+            shortcut.setSummary(R.string.accessibility_camera_button);
         } else {
             shortcut.setSummary(R.string.lockscreen_none);
         }
@@ -335,35 +343,28 @@ public class LockscreenFragment extends PreferenceFragment {
             String buttonStr = settings.get(mKey);
             if (!TextUtils.isEmpty(buttonStr)) {
                 if (buttonStr.contains("::")) {
-                    Shortcut shortcut = getShortcutInfo(mContext, buttonStr);
-                    if (shortcut != null) {
-                        return new ShortcutButton(mContext, shortcut);
-                    }
+                    return new ShortcutButton(mContext, buttonStr);
                 } else if (buttonStr.contains("/")) {
-                    ActivityInfo info = getActivityinfo(mContext, buttonStr);
-                    if (info != null) {
-                        return new ActivityButton(mContext, info);
-                    }
+                    return new ActivityButton(mContext, buttonStr);
+                } else if (buttonStr.equals(LOCKSCREEN_SHORTCUT_CAMERA) ||
+                        buttonStr.equals(LOCKSCREEN_SHORTCUT_VOICE_ASSIST)) {
+                    return new FakeButton(buttonStr);
+                } else if (buttonStr.equals(LOCKSCREEN_SHORTCUT_NONE)) {
+                    return new FakeButton("");
                 }
             }
             return null;
         }
     }
 
-    private static class ShortcutButton implements IntentButton {
-        private final Shortcut mShortcut;
+    private static class FakeButton implements IntentButton {
         private final IconState mIconState;
 
-        public ShortcutButton(Context context, Shortcut shortcut) {
-            mShortcut = shortcut;
+        public FakeButton(String description) {
             mIconState = new IconState();
-            mIconState.isVisible = true;
-            mIconState.drawable = shortcut.icon.loadDrawable(context).mutate();
-            mIconState.contentDescription = mShortcut.label;
-            int size = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 32,
-                    context.getResources().getDisplayMetrics());
-            mIconState.drawable = new ScalingDrawableWrapper(mIconState.drawable,
-                    size / (float) mIconState.drawable.getIntrinsicWidth());
+            mIconState.contentDescription = description;
+            mIconState.isVisible = false;
+            mIconState.drawable = new ColorDrawable(0);
             mIconState.tint = false;
         }
 
@@ -374,29 +375,86 @@ public class LockscreenFragment extends PreferenceFragment {
 
         @Override
         public Intent getIntent() {
-            return mShortcut.intent;
+            // Just a placeholder
+            return new Intent(Intent.ACTION_DIAL);
         }
     }
 
-    private static class ActivityButton implements IntentButton {
-        private final Intent mIntent;
-        private final IconState mIconState;
+    private static class ShortcutButton implements IntentButton {
+        private final Context mContext;
+        private final String mShortcut;
+        private IconState mIconState;
+        private Intent mIntent;
 
-        public ActivityButton(Context context, ActivityInfo info) {
-            mIntent = new Intent().setComponent(new ComponentName(info.packageName, info.name));
-            mIconState = new IconState();
-            mIconState.isVisible = true;
-            mIconState.drawable = info.loadIcon(context.getPackageManager()).mutate();
-            mIconState.contentDescription = info.loadLabel(context.getPackageManager());
-            int size = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 32,
-                    context.getResources().getDisplayMetrics());
-            mIconState.drawable = new ScalingDrawableWrapper(mIconState.drawable,
-                    size / (float) mIconState.drawable.getIntrinsicWidth());
-            mIconState.tint = false;
+        public ShortcutButton(Context context, String shortcut) {
+            mContext = context;
+            mShortcut = shortcut;
         }
 
         @Override
         public IconState getIcon() {
+            mIconState = new IconState();
+            mIconState.tint = false;
+
+            Shortcut shortcut = getShortcutInfo(mContext, mShortcut);
+            if (shortcut == null) {
+                mIconState.contentDescription = "";
+                mIconState.isVisible = false;
+                mIconState.drawable = new ColorDrawable(0);
+                mIntent = new Intent(Intent.ACTION_DIAL);
+                return mIconState;
+            }
+
+            mIntent = shortcut.intent;
+            mIconState.isVisible = true;
+            mIconState.drawable = shortcut.icon.loadDrawable(mContext).mutate();
+            mIconState.contentDescription = shortcut.label;
+            int size = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 32,
+                    mContext.getResources().getDisplayMetrics());
+            mIconState.drawable = new ScalingDrawableWrapper(mIconState.drawable,
+                    size / (float) mIconState.drawable.getIntrinsicWidth());
+            return mIconState;
+        }
+
+        @Override
+        public Intent getIntent() {
+            return mIntent;
+        }
+    }
+
+    private static class ActivityButton implements IntentButton {
+        private final Context mContext;
+        private final String mInfo;
+        private IconState mIconState;
+        private Intent mIntent;
+
+        public ActivityButton(Context context, String info) {
+            mContext = context;
+            mInfo = info;
+        }
+
+        @Override
+        public IconState getIcon() {
+            mIconState = new IconState();
+            mIconState.tint = false;
+
+            ActivityInfo info = getActivityinfo(mContext, mInfo);
+            if (info == null) {
+                mIconState.contentDescription = "";
+                mIconState.isVisible = false;
+                mIconState.drawable = new ColorDrawable(0);
+                mIntent = new Intent(Intent.ACTION_DIAL);
+                return mIconState;
+            }
+
+            mIntent = new Intent().setComponent(new ComponentName(info.packageName, info.name));
+            mIconState.isVisible = true;
+            mIconState.drawable = info.loadIcon(mContext.getPackageManager()).mutate();
+            mIconState.contentDescription = info.loadLabel(mContext.getPackageManager());
+            int size = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 32,
+                    mContext.getResources().getDisplayMetrics());
+            mIconState.drawable = new ScalingDrawableWrapper(mIconState.drawable,
+                    size / (float) mIconState.drawable.getIntrinsicWidth());
             return mIconState;
         }
 

--- a/packages/SystemUI/src/com/android/systemui/tuner/ShortcutPicker.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/ShortcutPicker.java
@@ -15,6 +15,9 @@
 package com.android.systemui.tuner;
 
 import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_LEFT_BUTTON;
+import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_SHORTCUT_CAMERA;
+import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_SHORTCUT_NONE;
+import static com.android.systemui.tuner.LockscreenFragment.LOCKSCREEN_SHORTCUT_VOICE_ASSIST;
 
 import android.content.Context;
 import android.content.pm.LauncherActivityInfo;
@@ -29,6 +32,7 @@ import android.support.v7.preference.PreferenceCategory;
 import android.support.v7.preference.PreferenceScreen;
 import android.support.v7.preference.PreferenceViewHolder;
 
+import com.android.systemui.assist.AssistManager;
 import com.android.systemui.Dependency;
 import com.android.systemui.R;
 import com.android.systemui.tuner.ShortcutParser.Shortcut;
@@ -40,8 +44,9 @@ import java.util.List;
 public class ShortcutPicker extends PreferenceFragment implements Tunable {
 
     private final ArrayList<SelectablePreference> mSelectablePreferences = new ArrayList<>();
+    private CustomPreference mDefaultPreference;
+    private CustomPreference mNonePreference;
     private String mKey;
-    private SelectablePreference mNonePreference;
     private TunerService mTunerService;
 
     @Override
@@ -52,11 +57,33 @@ public class ShortcutPicker extends PreferenceFragment implements Tunable {
         PreferenceCategory otherApps = new PreferenceCategory(context);
         otherApps.setTitle(R.string.tuner_other_apps);
 
-        mNonePreference = new SelectablePreference(context);
+        // True "none" preference
+        mNonePreference = new CustomPreference(context, LOCKSCREEN_SHORTCUT_NONE);
         mSelectablePreferences.add(mNonePreference);
         mNonePreference.setTitle(R.string.lockscreen_none);
         mNonePreference.setIcon(R.drawable.ic_remove_circle);
         screen.addPreference(mNonePreference);
+
+        // Default shortcuts (voice assist and camera)
+        mKey = getArguments().getString(ARG_PREFERENCE_ROOT);
+        if (LOCKSCREEN_LEFT_BUTTON.equals(mKey)) {
+            mDefaultPreference = new CustomPreference(context, LOCKSCREEN_SHORTCUT_VOICE_ASSIST);
+            mSelectablePreferences.add(mDefaultPreference);
+            if (canLaunchVoiceAssist()) {
+                mDefaultPreference.setTitle(R.string.accessibility_voice_assist_button);
+                mDefaultPreference.setIcon(R.drawable.ic_mic_26dp);
+            } else {
+                mDefaultPreference.setTitle(R.string.accessibility_phone_button);
+                mDefaultPreference.setIcon(R.drawable.ic_phone_24dp);
+            }
+            screen.addPreference(mDefaultPreference);
+        } else {
+            mDefaultPreference = new CustomPreference(context, LOCKSCREEN_SHORTCUT_CAMERA);
+            mSelectablePreferences.add(mDefaultPreference);
+            mDefaultPreference.setTitle(R.string.accessibility_camera_button);
+            mDefaultPreference.setIcon(R.drawable.ic_camera_alt_24dp);
+            screen.addPreference(mDefaultPreference);
+        }
 
         LauncherApps apps = getContext().getSystemService(LauncherApps.class);
         List<LauncherActivityInfo> activities = apps.getActivityList(null,
@@ -97,9 +124,13 @@ public class ShortcutPicker extends PreferenceFragment implements Tunable {
         //screen.addPreference(otherApps);
 
         setPreferenceScreen(screen);
-        mKey = getArguments().getString(ARG_PREFERENCE_ROOT);
         mTunerService = Dependency.get(TunerService.class);
         mTunerService.addTunable(this, mKey);
+    }
+
+    private boolean canLaunchVoiceAssist() {
+        AssistManager mAssistManager = Dependency.get(AssistManager.class);
+        return mAssistManager.canVoiceAssistBeLaunchedFromKeyguard();
     }
 
     @Override
@@ -195,6 +226,20 @@ public class ShortcutPicker extends PreferenceFragment implements Tunable {
         @Override
         public String toString() {
             return mShortcut.toString();
+        }
+    }
+
+    private static class CustomPreference extends SelectablePreference {
+        private String mIdentifier;
+
+        public CustomPreference(Context context, String id) {
+            super(context);
+            mIdentifier = id;
+        }
+
+        @Override
+        public String toString() {
+            return mIdentifier;
         }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerActivity.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerActivity.java
@@ -50,6 +50,8 @@ public class TunerActivity extends SettingsDrawerActivity implements
                 fragment = new PowerNotificationControlsFragment();
             } else if ("com.android.settings.action.STATUS_BAR_TUNER".equals(action)) {
                 fragment = new StatusBarTuner();
+            } else if ("com.android.settings.action.LOCK_SCREEN_TUNER".equals(action)) {
+                fragment = new LockscreenFragment();
             } else {
                 fragment = new TunerFragment();
             }


### PR DESCRIPTION
* Enables us to change lockscreen shortcuts, but they will be disabled as default.
  (Leaving SystemUI/config.xml as it is makes this possible.)

* Adds Voice Assist and Camera shortcuts to tuner and replaces "None" shortcut
  with real "None". Until now, "None" was either "None" or default shortcut, depending
  on "config_keyguardShowBlablaAffordance".

* It will be located under Settings > Security & Location > Lock screen preferences

Change-Id: Ibb107e550ff492219fb6fedd63f8fc8ee89753a9
Signed-off-by: eray orçunus <erayorcunus@gmail.com>