### PR TITLE
Fix ExternalStorageProvider always throw exception when rename

### DIFF
--- a/core/java/com/android/internal/content/FileSystemProvider.java
+++ b/core/java/com/android/internal/content/FileSystemProvider.java
@@ -236,6 +236,7 @@ public abstract class FileSystemProvider extends DocumentsProvider {
         displayName = FileUtils.buildValidFatFilename(displayName);
 
         final File before = getFileForDocId(docId);
+        final File beforeVisibleFile = getFileForDocId(docId, true);
         final File after = FileUtils.buildUniqueFile(before.getParentFile(), displayName);
         if (!before.renameTo(after)) {
             throw new IllegalStateException("Failed to rename to " + after);
@@ -245,7 +246,6 @@ public abstract class FileSystemProvider extends DocumentsProvider {
         onDocIdChanged(docId);
         onDocIdChanged(afterDocId);
 
-        final File beforeVisibleFile = getFileForDocId(docId, true);
         final File afterVisibleFile = getFileForDocId(afterDocId, true);
         moveInMediaStore(beforeVisibleFile, afterVisibleFile);
 


### PR DESCRIPTION
ExternalStorageProvider always throw exception when renameDocument
because it will check file exist when getFileForDocId. However,
beforeVisibleFile is not exist after rename, it will throw
exception. Fix it by put getting beforeVisibleFile before rename.

Test: manual test rename in DocumentsUI
Test: atest RenameActualProviderUiTest
Fix: 113302685
Fix: 115304092
Change-Id: I45d60d2f940e3dbc2b121f7cd28acc3c2d085ec4
Merged-In: I45d60d2f940e3dbc2b121f7cd28acc3c2d085ec4