### PR TITLE
fw/b: Prevent double interface restriction remove on interface name c…

### DIFF
--- a/services/core/java/com/android/server/NetworkManagementService.java
+++ b/services/core/java/com/android/server/NetworkManagementService.java
@@ -282,8 +282,10 @@ public class NetworkManagementService extends INetworkManagementService.Stub {
 
     @GuardedBy("mQuotaLock")
     private RestrictIf[] mRestrictIf = {
-            new RestrictIf(RESTRICT_USECASE_DATA, NetworkCapabilities.TRANSPORT_CELLULAR),
+            // Ordered by match preference (in the event we get a callback with
+            // multiple transports).
             new RestrictIf(RESTRICT_USECASE_VPN, NetworkCapabilities.TRANSPORT_VPN),
+            new RestrictIf(RESTRICT_USECASE_DATA, NetworkCapabilities.TRANSPORT_CELLULAR),
             new RestrictIf(RESTRICT_USECASE_WLAN, NetworkCapabilities.TRANSPORT_WIFI),
     };
 
@@ -360,6 +362,7 @@ public class NetworkManagementService extends INetworkManagementService.Stub {
                 for (RestrictIf restrictIf : mRestrictIf) {
                     if (nc.hasTransport(restrictIf.transport)) {
                         matchedRestrictIf = restrictIf;
+                        break;
                     }
                 }
                 if (matchedRestrictIf == null) {
@@ -1559,6 +1562,7 @@ public class NetworkManagementService extends INetworkManagementService.Stub {
                         continue;
                     }
                     setAppOnInterfaceLocked(restrictIf.useCase, restrictIf.ifName, uid, false);
+                    restrictIf.active.setValueAt(i, false);
                     // Use pending list to queue re-add.
                     // (Prefer keeping existing pending status if it exists.)
                     if (restrictIf.pending.indexOfKey(uid) < 0) {


### PR DESCRIPTION
…hange

* When temporarily removing a restriction owing to interface name
  change, update the boolean state array to match.  Otherwise, we
  get out of sync, follow-on double removes can occur and the system
  server will crash.

* In addition, it was observed that it is possible to receive a network
  callback for a (VPN) network that has both WIFI and VPN transports set (it
  looked transient rather than persisent but difficult to tell).  So make
  the list of use cases in priority of match order, putting VPN first.

Change-Id: If484b5a715e0a972769c847ea4549fd84afb3ccf