### PR TITLE
FODCircleView: Show while bouncer is requesting Pattern or PIN

### DIFF
--- a/packages/SystemUI/res-keyguard/values/lineage_dimens.xml
+++ b/packages/SystemUI/res-keyguard/values/lineage_dimens.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2020 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- The minimum bottom margin of the keyguard security container -->
+    <dimen name="kg_security_container_min_bottom_margin">0dp</dimen>
+</resources>

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
@@ -329,8 +329,11 @@ public class KeyguardSecurityContainer extends FrameLayout implements KeyguardSe
 
     @Override
     protected boolean fitSystemWindows(Rect insets) {
+        int minBottomMargin = getResources().getDimensionPixelSize(
+                R.dimen.kg_security_container_min_bottom_margin);
         // Consume bottom insets because we're setting the padding locally (for IME and navbar.)
-        setPadding(getPaddingLeft(), getPaddingTop(), getPaddingRight(), insets.bottom);
+        setPadding(getPaddingLeft(), getPaddingTop(), getPaddingRight(),
+                minBottomMargin > insets.bottom ? minBottomMargin : insets.bottom);
         insets.bottom = 0;
         return false;
     }

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -16,6 +16,7 @@
 
 package com.android.systemui.biometrics;
 
+import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -36,6 +37,8 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.ImageView;
 
+import com.android.internal.widget.LockPatternUtils;
+import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
 import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.keyguard.KeyguardUpdateMonitorCallback;
 import com.android.systemui.R;
@@ -75,6 +78,8 @@ public class FODCircleView extends ImageView {
 
     private Handler mHandler;
 
+    private LockPatternUtils mLockPatternUtils;
+
     private Timer mBurnInProtectionTimer;
 
     private IFingerprintInscreenCallback mFingerprintInscreenCallback =
@@ -109,11 +114,14 @@ public class FODCircleView extends ImageView {
         @Override
         public void onKeyguardBouncerChanged(boolean isBouncer) {
             mIsBouncer = isBouncer;
-
-            if (isBouncer) {
+            if (mUpdateMonitor.isFingerprintDetectionRunning()) {
+                if (isPinOrPattern(mUpdateMonitor.getCurrentUser()) || !isBouncer) {
+                    show();
+                } else {
+                    hide();
+                }
+            } else {
                 hide();
-            } else if (mUpdateMonitor.isFingerprintDetectionRunning()) {
-                show();
             }
         }
 
@@ -181,6 +189,8 @@ public class FODCircleView extends ImageView {
 
         updatePosition();
         hide();
+
+        mLockPatternUtils = new LockPatternUtils(mContext);
 
         mUpdateMonitor = KeyguardUpdateMonitor.getInstance(context);
         mUpdateMonitor.registerCallback(mMonitorCallback);
@@ -403,6 +413,20 @@ public class FODCircleView extends ImageView {
         }
 
         mWindowManager.updateViewLayout(this, mParams);
+    }
+
+    private boolean isPinOrPattern(int userId) {
+        int passwordQuality = mLockPatternUtils.getActivePasswordQuality(userId);
+        switch (passwordQuality) {
+            // PIN
+            case DevicePolicyManager.PASSWORD_QUALITY_NUMERIC:
+            case DevicePolicyManager.PASSWORD_QUALITY_NUMERIC_COMPLEX:
+            // Pattern
+            case DevicePolicyManager.PASSWORD_QUALITY_SOMETHING:
+                return true;
+        }
+
+        return false;
     }
 
     private class BurnInProtectionTask extends TimerTask {


### PR DESCRIPTION
Also allow devices to overlay the minimum bottom padding of the
keyguard security container so that they may shift the pattern/pin input
and the emergency call button up until the FOD icon does not obscure the
view.

Change-Id: Ie9652afc0d105199bf1e660221c82266ac8cf30a