### PR TITLE
SystemUI: Fix QS Detail Header

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSDetail.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSDetail.java
@@ -162,13 +162,13 @@ public class QSDetail extends LinearLayout {
         if (padding == null) {
             mQsDetailHeader.setPaddingRelative(
                     getResources().getDimensionPixelSize(R.dimen.qs_detail_header_padding),
-                    getPaddingTop(),
-                    getResources().getDimensionPixelSize(R.dimen.qs_detail_header_padding),
-                    getPaddingBottom()
+                    mQsDetailHeader.getPaddingTop(),
+                    getResources().getDimensionPixelSize(R.dimen.qs_panel_padding),
+                    mQsDetailHeader.getPaddingBottom()
             );
         } else {
-            mQsDetailHeader.setPadding(padding.first, getPaddingTop(),
-                    padding.second, getPaddingBottom());
+            mQsDetailHeader.setPadding(padding.first, mQsDetailHeader.getPaddingTop(),
+                    padding.second, mQsDetailHeader.getPaddingBottom());
         }
         return super.onApplyWindowInsets(insets);
     }


### PR DESCRIPTION
* Commit eff2c740e55668a4fdf427e64a8970a751830991 introduced some padding
  in case of an existing corner cutout (e.g. a camera in the corner of a
  display), so applies the size of the cutout as padding left/right
* it tries to keep top/bottom padding as-is by calling
  get[Top|Bottom]Padding while re-applying start and end paddings to
  restore the case with corner padding (e.g. after testing from developer
  settings) but fails to do so by calling it on the current view instead
  of the one of interest
* Fix that by getting the actual top/bottom paddings from the relevant
  header view
* Also fix the right padding - it should be qs_panel_padding according
  to the layout file

Test: QS Detail looks like before r37 merge
Test: Activate corner cutout and see if the inset applies properly,
  then deactivate it and see if the original layout restores
Change-Id: I5ba57deff1784fc4ea16649256965ad42dd78239