### PR TITLE
BLE: Fix NPE during start advertising

### DIFF
--- a/core/java/android/bluetooth/le/AdvertiseData.java
+++ b/core/java/android/bluetooth/le/AdvertiseData.java
@@ -170,8 +170,8 @@ public final class AdvertiseData implements Parcelable {
         }
         dest.writeByte((byte) (getIncludeTxPowerLevel() ? 1 : 0));
         dest.writeByte((byte) (getIncludeDeviceName() ? 1 : 0));
-        if(mTransportDiscoveryData != null) {
-            dest.writeInt(mTransportDiscoveryData.length);
+        dest.writeInt(mTransportDiscoveryData != null ? mTransportDiscoveryData.length : 0);
+        if (mTransportDiscoveryData != null) {
             dest.writeByteArray(mTransportDiscoveryData);
         }
     }


### PR DESCRIPTION
Use case:
Open any app that performs advertising.

Expected result:
BLE should Start advertisement.

Observed result :
Observed force close in BA App.

Fix:
set zero into parcel if transport
discovery data is empty.

Test: BLE Start advertisement successes after performing above use case.

CRs-Fixed: 2304532
Change-Id: Ica730f8d22367864308412621a8d87e625198bec