### PR TITLE
Fix color mismatch of pointers

### DIFF
--- a/core/java/com/android/internal/widget/PointerLocationView.java
+++ b/core/java/com/android/internal/widget/PointerLocationView.java
@@ -367,7 +367,7 @@ public class PointerLocationView extends View implements InputDeviceListener,
                 }
                 if (haveLast) {
                     canvas.drawLine(lastX, lastY, x, y, mPathPaint);
-                    final Paint paint = ps.mTraceCurrent[i] ? mCurrentPointPaint : mPaint;
+                    final Paint paint = ps.mTraceCurrent[i - 1] ? mCurrentPointPaint : mPaint;
                     canvas.drawPoint(lastX, lastY, paint);
                     drawn = true;
                 }


### PR DESCRIPTION
When drawing a point, it should be used the same index for coordinates and state.

Test: make
Signed-off-by: xuejianbao <xuejianbao@xiaomi.com>
Change-Id: I6d66e52b029d7b08663f62ab46125230b7f9a7c5