### PR TITLE
Purge unused native memory before Zygote fork events

### DIFF
--- a/core/jni/com_android_internal_os_Zygote.cpp
+++ b/core/jni/com_android_internal_os_Zygote.cpp
@@ -957,6 +957,13 @@ static pid_t ForkCommon(JNIEnv* env, bool is_system_server,
 
   android_fdsan_error_level fdsan_error_level = android_fdsan_get_error_level();
 
+  // Purge unused native memory in an attempt to reduce the amount of false
+  // sharing with the child process.  By reducing the size of the libc_malloc
+  // region shared with the child process we reduce the number of pages that
+  // transition to the private-dirty state when malloc adjusts the meta-data
+  // on each of the pages it is managing after the fork.
+  mallopt(M_PURGE, 0);
+
   pid_t pid = fork();
 
   if (pid == 0) {


### PR DESCRIPTION
This CL causes the Zygote to purge unused native memory before fork
events. This results in a decrease in the RSS before a fork, which
decreases false sharing between parent and child, and results in less
private dirty memory in the child when allocations and deallocations
begin to dirty bookkeeping data on pages in the anon:libc_malloc
memory region.

The result of these changes is a negligible change to application
startup times, the reduction of usap32 process private dirty memory by
40 KiB and usap64 process private dirty memory by 128 KiB.  Application
RSS and private dirty memory usage (for Calendar) was reduced by 804 KiB
and 624 KiB respectively.

Test: Launched Calendar 500 times
Change-Id: I52f72a5a02182a9e2748f7f87b45665059d9891a
Merged-In: I52f72a5a02182a9e2748f7f87b45665059d9891a