### PR TITLE
Add isFaceAuthEnabledForUser checks in KeyguardLiftController

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardLiftController.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardLiftController.kt
@@ -73,7 +73,9 @@ class KeyguardLiftController constructor(
         val onKeyguard = keyguardUpdateMonitor.isKeyguardVisible &&
                 !statusBarStateController.isDozing
 
-        val shouldListen = onKeyguard || bouncerVisible
+        val userId = KeyguardUpdateMonitor.getCurrentUser()
+        val isFaceEnabled = keyguardUpdateMonitor.isFaceAuthEnabledForUser(userId)
+        val shouldListen = (onKeyguard || bouncerVisible) && isFaceEnabled
         if (shouldListen != isListening) {
             isListening = shouldListen
 


### PR DESCRIPTION
When request pick gesture sensor, judge that if the current user does not turn on the face unlocking function, the sensor should not be Listening

Fixes: 161954958
Test: presubmit

Change-Id: I34552315049e07f123403fe693251edb460fef5d